### PR TITLE
Draft : wasm rayon

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,9 +1,3 @@
 [build]
 # Configuration for these lints should be placed in `.clippy.toml` at the crate root.
 rustflags = ["-Dwarnings"]
-
-[target.wasm32-unknown-unknown]
-rustflags = ["-C", "target-feature=+atomics,+bulk-memory"]
-
-[unstable]
-build-std = ["panic_abort", "std"]

--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,3 +1,9 @@
 [build]
 # Configuration for these lints should be placed in `.clippy.toml` at the crate root.
 rustflags = ["-Dwarnings"]
+
+[target.wasm32-unknown-unknown]
+rustflags = ["-C", "target-feature=+atomics,+bulk-memory"]
+
+[unstable]
+build-std = ["panic_abort", "std"]

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -79,7 +79,7 @@ jobs:
       - uses: jetli/wasm-pack-action@v0.4.0
         with:
           version: "latest"
-      - run: cd crates/prover && wasm-pack test --node
+      - run: cd crates/prover && wasm-pack test --chrome --headless -- --features parallel
         env:
           RUSTFLAGS: -C target-feature=+simd128
 

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -80,6 +80,23 @@ jobs:
       - uses: jetli/wasm-pack-action@v0.4.0
         with:
           version: "latest"
+      - run: cd crates/prover && wasm-pack test --chrome --headless --release -- -Z build-std=std,panic_abort
+        env:
+          RUSTFLAGS: "-C target-feature=+simd128,+atomics,+bulk-memory"
+
+  run-wasm32-unknown-tests-parallel:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: nightly-2025-04-06
+          targets: wasm32-unknown-unknown
+          components: rust-src
+      - uses: Swatinem/rust-cache@v2
+      - uses: jetli/wasm-pack-action@v0.4.0
+        with:
+          version: "latest"
       - run: cd crates/prover && wasm-pack test --chrome --headless --release -- -Z build-std=std,panic_abort --features parallel
         env:
           RUSTFLAGS: "-C target-feature=+simd128,+atomics,+bulk-memory"

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -75,6 +75,7 @@ jobs:
         with:
           toolchain: nightly-2025-04-06
           targets: wasm32-unknown-unknown
+          components: rust-src
       - uses: Swatinem/rust-cache@v2
       - uses: jetli/wasm-pack-action@v0.4.0
         with:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -80,7 +80,7 @@ jobs:
       - uses: jetli/wasm-pack-action@v0.4.0
         with:
           version: "latest"
-      - run: cd crates/prover && wasm-pack test --chrome --headless -- -Z build-std=std,panic_abort --features parallel
+      - run: cd crates/prover && wasm-pack test --chrome --headless --release -- -Z build-std=std,panic_abort --features parallel
         env:
           RUSTFLAGS: "-C target-feature=+simd128,+atomics,+bulk-memory"
 

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -80,9 +80,9 @@ jobs:
       - uses: jetli/wasm-pack-action@v0.4.0
         with:
           version: "latest"
-      - run: cd crates/prover && wasm-pack test --chrome --headless -- --features parallel
+      - run: cd crates/prover && wasm-pack test --chrome --headless -- -Z build-std=std,panic_abort --features parallel
         env:
-          RUSTFLAGS: -C target-feature=+simd128
+          RUSTFLAGS: "-C target-feature=+simd128,+atomics,+bulk-memory"
 
   run-neon-tests:
     runs-on: macos-latest-xlarge

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1113,7 +1113,6 @@ dependencies = [
  "hex",
  "indexmap",
  "itertools 0.12.1",
- "js-sys",
  "num-traits",
  "rand",
  "rayon",
@@ -1127,6 +1126,7 @@ dependencies = [
  "wasm-bindgen-futures",
  "wasm-bindgen-rayon",
  "wasm-bindgen-test",
+ "web-sys",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -373,6 +373,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "crossbeam-channel"
+version = "0.5.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "82b8f8f868b36967f9606790d1903570de9ceaf870a7bf9fbbd3016d636a2cb2"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
 name = "crossbeam-deque"
 version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -841,6 +850,7 @@ checksum = "b418a60154510ca1a002a752ca9714984e21e4241e804d32555251faf8b78ffa"
 dependencies = [
  "either",
  "rayon-core",
+ "wasm_sync",
 ]
 
 [[package]]
@@ -851,6 +861,7 @@ checksum = "1465873a3dfdaa8ae7cb14b4383657caab0b3e8a0aa9ae8e04b044854c8dfce2"
 dependencies = [
  "crossbeam-deque",
  "crossbeam-utils",
+ "wasm_sync",
 ]
 
 [[package]]
@@ -1102,6 +1113,7 @@ dependencies = [
  "hex",
  "indexmap",
  "itertools 0.12.1",
+ "js-sys",
  "num-traits",
  "rand",
  "rayon",
@@ -1112,6 +1124,8 @@ dependencies = [
  "thiserror",
  "tracing",
  "tracing-subscriber",
+ "wasm-bindgen-futures",
+ "wasm-bindgen-rayon",
  "wasm-bindgen-test",
 ]
 
@@ -1375,6 +1389,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "wasm-bindgen-rayon"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a16c60a56c81e4dc3b9c43d76ba5633e1c0278211d59a9cb07d61b6cd1c6583"
+dependencies = [
+ "crossbeam-channel",
+ "js-sys",
+ "rayon",
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "wasm-bindgen-shared"
 version = "0.2.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1405,6 +1431,17 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.96",
+]
+
+[[package]]
+name = "wasm_sync"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cff360cade7fec41ff0e9d2cda57fe58258c5f16def0e21302394659e6bbb0ea"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+ "web-sys",
 ]
 
 [[package]]

--- a/crates/prover/Cargo.toml
+++ b/crates/prover/Cargo.toml
@@ -33,7 +33,10 @@ tracing-subscriber = "0.3.18"
 aligned = "0.4.2"
 test-log = { version = "0.2.15", features = ["trace"] }
 [target.'cfg(all(target_family = "wasm", not(target_os = "wasi")))'.dev-dependencies]
+js-sys = "0.3"
 wasm-bindgen-test = "0.3.43"
+wasm-bindgen-futures = "0.4"
+wasm-bindgen-rayon = { version = "1.3", features = ["no-bundler"] }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dev-dependencies.criterion]
 features = ["html_reports"]

--- a/crates/prover/Cargo.toml
+++ b/crates/prover/Cargo.toml
@@ -28,15 +28,16 @@ tracing.workspace = true
 rayon = { version = "1.10.0", optional = true }
 serde = { version = "1.0", features = ["derive"] }
 tracing-subscriber = "0.3.18"
+[target.'cfg(all(target_family = "wasm", not(target_os = "wasi")))'.dependencies]
+web-sys = { version = "0.3",  features = [ "Navigator", "console" ]}
+wasm-bindgen-futures = "0.4"
+wasm-bindgen-rayon = { version = "1.3", features = ["no-bundler"] }
 
 [dev-dependencies]
 aligned = "0.4.2"
 test-log = { version = "0.2.15", features = ["trace"] }
 [target.'cfg(all(target_family = "wasm", not(target_os = "wasi")))'.dev-dependencies]
-js-sys = "0.3"
 wasm-bindgen-test = "0.3.43"
-wasm-bindgen-futures = "0.4"
-wasm-bindgen-rayon = { version = "1.3", features = ["no-bundler"] }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dev-dependencies.criterion]
 features = ["html_reports"]

--- a/crates/prover/Cargo.toml
+++ b/crates/prover/Cargo.toml
@@ -4,7 +4,7 @@ version.workspace = true
 edition.workspace = true
 
 [features]
-parallel = ["rayon"]
+parallel = ["rayon", "wasm-bindgen-futures", "wasm-bindgen-rayon"]
 slow-tests = []
 tracing = []
 
@@ -28,10 +28,11 @@ tracing.workspace = true
 rayon = { version = "1.10.0", optional = true }
 serde = { version = "1.0", features = ["derive"] }
 tracing-subscriber = "0.3.18"
+
 [target.'cfg(all(target_family = "wasm", not(target_os = "wasi")))'.dependencies]
-web-sys = { version = "0.3",  features = [ "Navigator", "console" ]}
-wasm-bindgen-futures = "0.4"
-wasm-bindgen-rayon = { version = "1.3", features = ["no-bundler"] }
+web-sys = { version = "0.3", features = [ "console", "Performance", "Window" ] }
+wasm-bindgen-futures = { version = "0.4", optional = true }
+wasm-bindgen-rayon = { version = "1.3", features = ["no-bundler"], optional = true}
 
 [dev-dependencies]
 aligned = "0.4.2"

--- a/crates/prover/src/core/backend/simd/grind.rs
+++ b/crates/prover/src/core/backend/simd/grind.rs
@@ -91,6 +91,7 @@ impl GrindOps<Poseidon252Channel> for SimdBackend {
 #[cfg(test)]
 mod tests {
 
+    #[cfg(not(target_arch = "wasm32"))]
     #[cfg(feature = "parallel")]
     #[test]
     fn test_grind_blake_is_determinstic() {

--- a/crates/prover/src/examples/poseidon/mod.rs
+++ b/crates/prover/src/examples/poseidon/mod.rs
@@ -394,9 +394,6 @@ mod tests {
 
     use itertools::Itertools;
     use num_traits::One;
-    #[cfg(feature = "parallel")]
-    #[cfg(all(target_family = "wasm", not(target_os = "wasi")))]
-    pub use wasm_bindgen_rayon::init_thread_pool;
 
     use crate::constraint_framework::assert_constraints_on_polys;
     use crate::core::air::Component;
@@ -412,43 +409,16 @@ mod tests {
         gen_trace, prove_poseidon, PoseidonElements,
     };
     use crate::math::matrix::{RowMajorMatrix, SquareMatrix};
+    #[cfg(all(target_family = "wasm", not(target_os = "wasi")))]
+    use crate::wasm_multithread::init_wasm_mt;
 
     #[cfg(all(target_family = "wasm", not(target_os = "wasi")))]
     wasm_bindgen_test::wasm_bindgen_test_configure!(run_in_browser);
 
-    #[cfg(feature = "parallel")]
-    #[cfg(all(target_family = "wasm", not(target_os = "wasi")))]
-    fn get_hardware_concurrency_js_sys() -> usize {
-        use js_sys::wasm_bindgen::{JsCast, JsValue};
-
-        let global = js_sys::global().unchecked_into::<js_sys::Object>();
-        let nav = js_sys::Reflect::get(&global, &JsValue::from_str("navigator"))
-            .ok()
-            .and_then(|v| v.dyn_into::<js_sys::Object>().ok())
-            .unwrap_or_default();
-        let hc = js_sys::Reflect::get(&nav, &JsValue::from_str("hardwareConcurrency"))
-            .ok()
-            .and_then(|v| v.as_f64())
-            .unwrap_or(1.0);
-        hc as usize
-    }
-
-    #[cfg(feature = "parallel")]
-    #[cfg(all(target_family = "wasm", not(target_os = "wasi")))]
-    pub async fn start_pool() {
-        let num_threads = get_hardware_concurrency_js_sys();
-        let promise: js_sys::Promise = init_thread_pool(num_threads);
-        let future = wasm_bindgen_futures::JsFuture::from(promise);
-        let _result = future.await.unwrap();
-    }
-
     #[cfg(all(target_family = "wasm", not(target_os = "wasi")))]
     #[wasm_bindgen_test::wasm_bindgen_test]
     async fn test_poseidon_prove_wasm() {
-        #[cfg(feature = "parallel")]
-        {
-            start_pool().await;
-        }
+        init_wasm_mt().await;
 
         const LOG_N_INSTANCES: u32 = 10;
         let config = PcsConfig {

--- a/crates/prover/src/examples/poseidon/mod.rs
+++ b/crates/prover/src/examples/poseidon/mod.rs
@@ -394,6 +394,7 @@ mod tests {
 
     use itertools::Itertools;
     use num_traits::One;
+    #[cfg(feature = "parallel")]
     #[cfg(all(target_family = "wasm", not(target_os = "wasi")))]
     pub use wasm_bindgen_rayon::init_thread_pool;
 
@@ -415,6 +416,7 @@ mod tests {
     #[cfg(all(target_family = "wasm", not(target_os = "wasi")))]
     wasm_bindgen_test::wasm_bindgen_test_configure!(run_in_browser);
 
+    #[cfg(feature = "parallel")]
     #[cfg(all(target_family = "wasm", not(target_os = "wasi")))]
     fn get_hardware_concurrency_js_sys() -> usize {
         use js_sys::wasm_bindgen::{JsCast, JsValue};
@@ -431,6 +433,7 @@ mod tests {
         hc as usize
     }
 
+    #[cfg(feature = "parallel")]
     #[cfg(all(target_family = "wasm", not(target_os = "wasi")))]
     pub async fn start_pool() {
         let num_threads = get_hardware_concurrency_js_sys();
@@ -442,7 +445,10 @@ mod tests {
     #[cfg(all(target_family = "wasm", not(target_os = "wasi")))]
     #[wasm_bindgen_test::wasm_bindgen_test]
     async fn test_poseidon_prove_wasm() {
-        start_pool().await;
+        #[cfg(feature = "parallel")]
+        {
+            start_pool().await;
+        }
 
         const LOG_N_INSTANCES: u32 = 10;
         let config = PcsConfig {

--- a/crates/prover/src/examples/poseidon/mod.rs
+++ b/crates/prover/src/examples/poseidon/mod.rs
@@ -410,24 +410,35 @@ mod tests {
     };
     use crate::math::matrix::{RowMajorMatrix, SquareMatrix};
     #[cfg(all(target_family = "wasm", not(target_os = "wasi")))]
-    use crate::wasm_multithread::init_wasm_mt;
+    use crate::wasm_multithread::{init_wasm_mt, wasm_timer_now};
 
+    // Ideally tests would run in worker mode, but we use the main thread
+    // to access web_sys features.
     #[cfg(all(target_family = "wasm", not(target_os = "wasi")))]
     wasm_bindgen_test::wasm_bindgen_test_configure!(run_in_browser);
 
     #[cfg(all(target_family = "wasm", not(target_os = "wasi")))]
     #[wasm_bindgen_test::wasm_bindgen_test]
     async fn test_poseidon_prove_wasm() {
-        init_wasm_mt().await;
+        const NUM_THREADS: usize = 8;
+        init_wasm_mt(NUM_THREADS).await;
 
-        const LOG_N_INSTANCES: u32 = 10;
-        let config = PcsConfig {
-            pow_bits: 10,
-            fri_config: FriConfig::new(5, 1, 64),
-        };
+        let start = wasm_timer_now();
+        {
+            const LOG_N_INSTANCES: u32 = 17;
+            let config = PcsConfig {
+                pow_bits: 10,
+                fri_config: FriConfig::new(5, 1, 64),
+            };
 
-        // Prove.
-        prove_poseidon(LOG_N_INSTANCES, config);
+            // Prove.
+            prove_poseidon(LOG_N_INSTANCES, config);
+        }
+        let end = wasm_timer_now();
+        web_sys::console::log_1(&format!("Execution time: {} ms", end - start).into());
+
+        // Use this to redirect console output to stdout when running in headless mode
+        // panic!("this is panic");
     }
 
     #[test]

--- a/crates/prover/src/examples/poseidon/mod.rs
+++ b/crates/prover/src/examples/poseidon/mod.rs
@@ -394,6 +394,8 @@ mod tests {
 
     use itertools::Itertools;
     use num_traits::One;
+    #[cfg(all(target_family = "wasm", not(target_os = "wasi")))]
+    pub use wasm_bindgen_rayon::init_thread_pool;
 
     use crate::constraint_framework::assert_constraints_on_polys;
     use crate::core::air::Component;
@@ -411,8 +413,37 @@ mod tests {
     use crate::math::matrix::{RowMajorMatrix, SquareMatrix};
 
     #[cfg(all(target_family = "wasm", not(target_os = "wasi")))]
+    wasm_bindgen_test::wasm_bindgen_test_configure!(run_in_browser);
+
+    #[cfg(all(target_family = "wasm", not(target_os = "wasi")))]
+    fn get_hardware_concurrency_js_sys() -> usize {
+        use js_sys::wasm_bindgen::{JsCast, JsValue};
+
+        let global = js_sys::global().unchecked_into::<js_sys::Object>();
+        let nav = js_sys::Reflect::get(&global, &JsValue::from_str("navigator"))
+            .ok()
+            .and_then(|v| v.dyn_into::<js_sys::Object>().ok())
+            .unwrap_or_default();
+        let hc = js_sys::Reflect::get(&nav, &JsValue::from_str("hardwareConcurrency"))
+            .ok()
+            .and_then(|v| v.as_f64())
+            .unwrap_or(1.0);
+        hc as usize
+    }
+
+    #[cfg(all(target_family = "wasm", not(target_os = "wasi")))]
+    pub async fn start_pool() {
+        let num_threads = get_hardware_concurrency_js_sys();
+        let promise: js_sys::Promise = init_thread_pool(num_threads);
+        let future = wasm_bindgen_futures::JsFuture::from(promise);
+        let _result = future.await.unwrap();
+    }
+
+    #[cfg(all(target_family = "wasm", not(target_os = "wasi")))]
     #[wasm_bindgen_test::wasm_bindgen_test]
-    fn test_poseidon_prove_wasm() {
+    async fn test_poseidon_prove_wasm() {
+        start_pool().await;
+
         const LOG_N_INSTANCES: u32 = 10;
         let config = PcsConfig {
             pow_bits: 10,

--- a/crates/prover/src/lib.rs
+++ b/crates/prover/src/lib.rs
@@ -23,3 +23,6 @@ pub mod math;
 
 #[cfg(feature = "tracing")]
 pub mod tracing;
+
+#[cfg(all(target_family = "wasm", not(target_os = "wasi")))]
+pub mod wasm_multithread;

--- a/crates/prover/src/wasm_multithread/mod.rs
+++ b/crates/prover/src/wasm_multithread/mod.rs
@@ -1,0 +1,33 @@
+#[cfg(all(feature = "parallel", target_family = "wasm", not(target_os = "wasi")))]
+pub use wasm_bindgen_rayon::init_thread_pool;
+
+#[cfg(all(feature = "parallel", target_family = "wasm", not(target_os = "wasi")))]
+fn get_hardware_concurrency() -> usize {
+    web_sys::window()
+        .map(|w| w.navigator().hardware_concurrency() as usize)
+        .unwrap_or_else(|| {
+            web_sys::console::warn_1(
+                &"navigator.hardwareConcurrency unavailable; defaulting to 1".into(),
+            );
+            1
+        })
+}
+
+#[cfg(all(feature = "parallel", target_family = "wasm", not(target_os = "wasi")))]
+pub async fn rayon_init_thread_pool() {
+    let num_threads = get_hardware_concurrency();
+    let promise = init_thread_pool(num_threads);
+    if let Err(err) = wasm_bindgen_futures::JsFuture::from(promise).await {
+        web_sys::console::error_1(&format!("Failed to start pool: {:?}", err).into());
+    } else {
+        web_sys::console::info_1(
+            &format!("Rayon pool started with {} threads", num_threads).into(),
+        );
+    }
+}
+
+#[cfg(all(target_family = "wasm", not(target_os = "wasi")))]
+pub async fn init_wasm_mt() {
+    #[cfg(feature = "parallel")]
+    rayon_init_thread_pool().await;
+}

--- a/crates/prover/src/wasm_multithread/mod.rs
+++ b/crates/prover/src/wasm_multithread/mod.rs
@@ -2,21 +2,9 @@
 pub use wasm_bindgen_rayon::init_thread_pool;
 
 #[cfg(all(feature = "parallel", target_family = "wasm", not(target_os = "wasi")))]
-fn get_hardware_concurrency() -> usize {
-    web_sys::window()
-        .map(|w| w.navigator().hardware_concurrency() as usize)
-        .unwrap_or_else(|| {
-            web_sys::console::warn_1(
-                &"navigator.hardwareConcurrency unavailable; defaulting to 1".into(),
-            );
-            1
-        })
-}
-
-#[cfg(all(feature = "parallel", target_family = "wasm", not(target_os = "wasi")))]
-pub async fn rayon_init_thread_pool() {
-    let num_threads = get_hardware_concurrency();
+async fn rayon_init_thread_pool(num_threads: usize) {
     let promise = init_thread_pool(num_threads);
+    // Alternatively, num_threads can be set dynamically using hardware_concurrency()
     if let Err(err) = wasm_bindgen_futures::JsFuture::from(promise).await {
         web_sys::console::error_1(&format!("Failed to start pool: {:?}", err).into());
     } else {
@@ -27,7 +15,27 @@ pub async fn rayon_init_thread_pool() {
 }
 
 #[cfg(all(target_family = "wasm", not(target_os = "wasi")))]
-pub async fn init_wasm_mt() {
+pub async fn init_wasm_mt(num_threads: usize) {
     #[cfg(feature = "parallel")]
-    rayon_init_thread_pool().await;
+    rayon_init_thread_pool(num_threads).await;
+
+    #[cfg(not(feature = "parallel"))]
+    web_sys::console::log_1(
+        &format!(
+            "Parallel feature is not enabled, num_threads: {} will be ignored",
+            num_threads
+        )
+        .into(),
+    );
+}
+
+#[cfg(all(target_family = "wasm", not(target_os = "wasi")))]
+pub fn wasm_timer_now() -> f64 {
+    web_sys::window()
+        .and_then(|win| win.performance())
+        .map(|p| p.now())
+        .unwrap_or_else(|| {
+            web_sys::console::warn_1(&"window.performance.now() unavailable; using 0.0".into());
+            0.0
+        })
 }


### PR DESCRIPTION
* Added `wasm-bindgen-rayon` for parallelism.
* Switched the test runner from Node.js to headless Chrome, since `wasm-bindgen-rayon` [only works on the web target](https://github.com/RReverser/wasm-bindgen-rayon?tab=readme-ov-file#building-rust-code).
* Enabled the `atomics` and `bulk-memory` [features](https://github.com/RReverser/wasm-bindgen-rayon?tab=readme-ov-file#using-command-line-params) to support `wasm-bindgen-rayon`.

![image](https://github.com/user-attachments/assets/7bacfdc6-6ba4-4803-b981-91b5bef76b3a)
* This benchmark was executed on an Apple M3 Pro with an 11-core CPU.
* On Chrome, using 8 threads resulted in approximately 25% performance improvement compared to the single-threaded baseline.
* In headless environments, the thread pool initializes successfully; however, performance degrades—likely due to limitations in thread count or other execution constraints specific to headless browsers.
